### PR TITLE
ajout Redis pour cache TTS, rate limiting et blacklist JWT

### DIFF
--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getToken } from 'next-auth/jwt';
+import { redis, TTL, KEYS } from '@/lib/redis';
+
+export async function POST(request: NextRequest) {
+  const token = await getToken({ req: request, secret: process.env.NEXTAUTH_SECRET });
+
+  if (token?.jti) {
+    // Calcul du TTL restant du token pour ne pas stocker indéfiniment
+    const exp = token.exp as number | undefined;
+    const remainingTtl = exp ? Math.max(exp - Math.floor(Date.now() / 1000), 1) : TTL.JWT_BLACKLIST;
+
+    await redis.set(KEYS.jwtBlacklist(token.jti as string), '1', { ex: remainingTtl });
+    console.log('JWT blacklisté:', (token.jti as string).substring(0, 8));
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/app/api/tts/route.ts
+++ b/app/api/tts/route.ts
@@ -1,5 +1,11 @@
 import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth/next';
+import { createHash } from 'crypto';
 import { API_CONFIG } from '@/lib/configTTS';
+import { authOptions } from '@/lib/auth';
+import { redis, TTL, KEYS } from '@/lib/redis';
+
+const RATE_LIMIT_MAX = 20; // requêtes par heure
 
 export async function POST(request: Request) {
   try {
@@ -12,8 +18,6 @@ export async function POST(request: Request) {
       );
     }
 
-    console.log('Clé API:', API_CONFIG.GOOGLE_TTS.API_KEY ? 'Présente' : 'Manquante');
-    
     if (!API_CONFIG.GOOGLE_TTS.API_KEY) {
       console.error('La clé API Google Text-to-Speech n\'est pas configurée');
       return NextResponse.json(
@@ -22,20 +26,39 @@ export async function POST(request: Request) {
       );
     }
 
-    console.log('Envoi de la requête à l\'API Google Text-to-Speech...');
-    console.log('URL:', `${API_CONFIG.GOOGLE_TTS.BASE_URL}${API_CONFIG.GOOGLE_TTS.ENDPOINTS.SYNTHESIZE}`);
-    console.log('Paramètres:', {
-      text: text.substring(0, 50) + '...',
-      settings
-    });
+    // --- Rate limiting ---
+    const session = await getServerSession(authOptions);
+    if (session?.user?.id) {
+      const rateLimitKey = KEYS.rateLimit(session.user.id);
+      const count = await redis.incr(rateLimitKey);
+      if (count === 1) {
+        await redis.expire(rateLimitKey, TTL.RATE_LIMIT_WINDOW);
+      }
+      if (count > RATE_LIMIT_MAX) {
+        return NextResponse.json(
+          { error: `Limite atteinte : ${RATE_LIMIT_MAX} conversions par heure` },
+          { status: 429 }
+        );
+      }
+    }
 
+    // --- Cache TTS ---
+    const cachePayload = JSON.stringify({ text, settings });
+    const cacheHash = createHash('sha256').update(cachePayload).digest('hex');
+    const cacheKey = KEYS.ttsCache(cacheHash);
+
+    const cached = await redis.get<string>(cacheKey);
+    if (cached) {
+      console.log('Cache hit TTS:', cacheHash.substring(0, 8));
+      return NextResponse.json({ audioContent: cached, fromCache: true });
+    }
+
+    // --- Appel Google TTS ---
     const response = await fetch(
       `${API_CONFIG.GOOGLE_TTS.BASE_URL}${API_CONFIG.GOOGLE_TTS.ENDPOINTS.SYNTHESIZE}?key=${API_CONFIG.GOOGLE_TTS.API_KEY}`,
       {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           input: { text },
           voice: {
@@ -54,21 +77,25 @@ export async function POST(request: Request) {
 
     if (!response.ok) {
       const error = await response.json();
-      console.error('Erreur de l\'API Google Text-to-Speech:', error);
+      console.error('Erreur Google TTS:', error);
       return NextResponse.json(
-        { error: error.error?.message || "Une erreur est survenue lors de la conversion" },
+        { error: error.error?.message || 'Une erreur est survenue lors de la conversion' },
         { status: response.status }
       );
     }
 
     const data = await response.json();
-    console.log('Réponse reçue de l\'API Google Text-to-Speech');
+
+    // Mise en cache du résultat
+    await redis.set(cacheKey, data.audioContent, { ex: TTL.TTS_CACHE });
+    console.log('Cache set TTS:', cacheHash.substring(0, 8));
+
     return NextResponse.json(data);
   } catch (error) {
     console.error('Erreur lors de la conversion:', error);
     return NextResponse.json(
-      { error: "Une erreur est survenue lors de la conversion" },
+      { error: 'Une erreur est survenue lors de la conversion' },
       { status: 500 }
     );
   }
-} 
+}

--- a/hooks/useAuth.ts
+++ b/hooks/useAuth.ts
@@ -55,6 +55,7 @@ export function useAuth() {
 
   const logout = async () => {
     try {
+      await fetch('/api/auth/logout', { method: 'POST' })
       await signOut({
         redirect: true,
         callbackUrl: '/'

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -2,6 +2,7 @@ import { NextAuthOptions } from 'next-auth'
 import CredentialsProvider from 'next-auth/providers/credentials'
 import { prisma } from '@/lib/prisma'
 import bcrypt from 'bcryptjs'
+import { randomUUID } from 'crypto'
 
 export const authOptions: NextAuthOptions = {
   providers: [
@@ -55,12 +56,12 @@ export const authOptions: NextAuthOptions = {
   },
   callbacks: {
     async jwt({ token, user }) {
-      // Mettre à jour le token seulement quand nécessaire
       if (user) {
         token.id = user.id
         token.firstName = user.firstName
         token.lastName = user.lastName
         token.email = user.email
+        token.jti = randomUUID() // identifiant unique pour la blacklist
       }
       return token
     },

--- a/lib/redis.ts
+++ b/lib/redis.ts
@@ -1,0 +1,19 @@
+import { Redis } from '@upstash/redis'
+
+export const redis = new Redis({
+  url: process.env.UPSTASH_REDIS_REST_URL!,
+  token: process.env.UPSTASH_REDIS_REST_TOKEN!,
+})
+
+// TTL constants (in seconds)
+export const TTL = {
+  TTS_CACHE: 60 * 60 * 24,      // 24h
+  RATE_LIMIT_WINDOW: 60 * 60,   // 1h
+  JWT_BLACKLIST: 60 * 60 * 24 * 30, // 30 jours (durée max d'un JWT)
+}
+
+export const KEYS = {
+  ttsCache: (hash: string) => `tts:cache:${hash}`,
+  rateLimit: (userId: string) => `ratelimit:${userId}`,
+  jwtBlacklist: (jti: string) => `jwt:blacklist:${jti}`,
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { getToken } from 'next-auth/jwt';
+import { redis, KEYS } from '@/lib/redis';
 import type { NextRequest } from 'next/server';
 
 export async function middleware(req: NextRequest) {
@@ -7,6 +8,17 @@ export async function middleware(req: NextRequest) {
         req,
         secret: process.env.NEXTAUTH_SECRET
     });
+
+    // Vérifier si le token est blacklisté (logout explicite)
+    if (token?.jti) {
+        const isBlacklisted = await redis.exists(KEYS.jwtBlacklist(token.jti as string));
+        if (isBlacklisted) {
+            const loginUrl = new URL('/login', req.url);
+            const response = NextResponse.redirect(loginUrl);
+            response.cookies.delete('next-auth.session-token');
+            return response;
+        }
+    }
 
     // Rediriger les utilisateurs connectés depuis login/signup vers account
     if ((req.nextUrl.pathname === '/login' || req.nextUrl.pathname === '/sign-up') && token) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@types/bcryptjs": "^2.4.6",
         "@types/jsonwebtoken": "^9.0.9",
         "@types/next-auth": "^3.13.0",
+        "@upstash/redis": "^1.37.0",
         "bcryptjs": "^3.0.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -2668,6 +2669,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@upstash/redis": {
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.37.0.tgz",
+      "integrity": "sha512-LqOJ3+XWPLSZ2rGSed5DYG3ixybxb8EhZu3yQqF7MdZX1wLBG/FRcI6xcUZXHy/SS7mmXWyadrud0HJHkOc+uw==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
       }
     },
     "node_modules/acorn": {
@@ -7659,6 +7669,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "6.19.8",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@types/bcryptjs": "^2.4.6",
     "@types/jsonwebtoken": "^9.0.9",
     "@types/next-auth": "^3.13.0",
+    "@upstash/redis": "^1.37.0",
     "bcryptjs": "^3.0.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",


### PR DESCRIPTION
- Ajout de lib/redis.ts avec client Upstash, constantes TTL et KEYS
- Cache des réponses Google TTS (24h) via hash SHA-256 du payload
- Rate limiting par utilisateur (20 req/heure) sur la route TTS
- Blacklist JWT au logout via Redis pour invalider les sessions explicitement
- Nouveau endpoint POST /api/auth/logout qui blackliste le jti du token
- Middleware vérifie la blacklist avant chaque requête protégée
- Ajout du jti (randomUUID) dans le callback JWT pour identifier chaque token
- Typage corrigé : NextRequest à la place de Request dans la route logout